### PR TITLE
style(main): import Montserrat font from statics

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2,15 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: 'Montserrat';
+  src: url('/fonts/Montserrat/static/Montserrat-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}
+
 :root {
   @apply bg-main-dark-blue;
   font-family: 'Montserrat';
 }
+
 a {
   @apply text-tertiary-blue;
 }
 
 input {
   background-color: transparent;
-
 }


### PR DESCRIPTION
Hey, Platformatic team!

I was playing around with the `@platformatic/ui-components` and I've seen that the used font _Montserrat_ is never imported when you run the app with Vite.

This little fix imports the font from the static path.
