### PR TITLE
Bugfix/unmatched props with default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ $ npm run storybook
 ## Storybook public link
 
 https://ui.platformatic.cloud/
+
+
+## New version: commands list
+
+```
+git checkout main
+git pull
+npm install
+npm version patch
+git push origin main
+npm publish
+```

--- a/src/components/icons/AddIcon.jsx
+++ b/src/components/icons/AddIcon.jsx
@@ -22,7 +22,7 @@ const AddIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -72,7 +72,7 @@ AddIcon.propTypes = {
 
 AddIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default AddIcon

--- a/src/components/icons/AlertIcon.jsx
+++ b/src/components/icons/AlertIcon.jsx
@@ -23,7 +23,7 @@ const AlertIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -75,7 +75,7 @@ AlertIcon.propTypes = {
 
 AlertIcon.defaultProps = {
   color: 'red',
-  size: 'small'
+  size: 'medium'
 }
 
 export default AlertIcon

--- a/src/components/icons/AllInOneIcon.jsx
+++ b/src/components/icons/AllInOneIcon.jsx
@@ -33,7 +33,7 @@ const AllInOneIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -105,7 +105,7 @@ AllInOneIcon.propTypes = {
 
 AllInOneIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default AllInOneIcon

--- a/src/components/icons/ApiCloudIcon.jsx
+++ b/src/components/icons/ApiCloudIcon.jsx
@@ -27,7 +27,7 @@ const ApiCloudIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -87,7 +87,7 @@ ApiCloudIcon.propTypes = {
 
 ApiCloudIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ApiCloudIcon

--- a/src/components/icons/ApiIcon.jsx
+++ b/src/components/icons/ApiIcon.jsx
@@ -24,7 +24,7 @@ const ApiIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -78,7 +78,7 @@ ApiIcon.propTypes = {
 
 ApiIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ApiIcon

--- a/src/components/icons/AppIcon.jsx
+++ b/src/components/icons/AppIcon.jsx
@@ -25,7 +25,7 @@ const AppIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -79,7 +79,7 @@ AppIcon.propTypes = {
 
 AppIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default AppIcon

--- a/src/components/icons/ArrowDownFullIcon.jsx
+++ b/src/components/icons/ArrowDownFullIcon.jsx
@@ -22,7 +22,7 @@ const ArrowDownFullIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -70,7 +70,7 @@ ArrowDownFullIcon.propTypes = {
 
 ArrowDownFullIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ArrowDownFullIcon

--- a/src/components/icons/ArrowDownIcon.jsx
+++ b/src/components/icons/ArrowDownIcon.jsx
@@ -21,7 +21,7 @@ const ArrowDownIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -69,7 +69,7 @@ ArrowDownIcon.propTypes = {
 
 ArrowDownIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ArrowDownIcon

--- a/src/components/icons/ArrowLeftIcon.jsx
+++ b/src/components/icons/ArrowLeftIcon.jsx
@@ -21,7 +21,7 @@ const ArrowLeftIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -69,7 +69,7 @@ ArrowLeftIcon.propTypes = {
 
 ArrowLeftIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ArrowLeftIcon

--- a/src/components/icons/ArrowRightIcon.jsx
+++ b/src/components/icons/ArrowRightIcon.jsx
@@ -21,7 +21,7 @@ const ArrowRightIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -69,7 +69,7 @@ ArrowRightIcon.propTypes = {
 
 ArrowRightIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ArrowRightIcon

--- a/src/components/icons/ArrowUpIcon.jsx
+++ b/src/components/icons/ArrowUpIcon.jsx
@@ -21,7 +21,7 @@ const ArrowDownIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -69,7 +69,7 @@ ArrowDownIcon.propTypes = {
 
 ArrowDownIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default ArrowDownIcon

--- a/src/components/icons/Calendar1DayIcon.jsx
+++ b/src/components/icons/Calendar1DayIcon.jsx
@@ -27,7 +27,7 @@ const Calendar1DayIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -84,7 +84,7 @@ Calendar1DayIcon.propTypes = {
 
 Calendar1DayIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default Calendar1DayIcon

--- a/src/components/icons/Calendar7DaysIcon.jsx
+++ b/src/components/icons/Calendar7DaysIcon.jsx
@@ -27,7 +27,7 @@ const Calendar7DaysIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -82,7 +82,7 @@ Calendar7DaysIcon.propTypes = {
 
 Calendar7DaysIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default Calendar7DaysIcon

--- a/src/components/icons/CalendarIcon.jsx
+++ b/src/components/icons/CalendarIcon.jsx
@@ -31,7 +31,7 @@ const CalendarIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -96,7 +96,7 @@ CalendarIcon.propTypes = {
 
 CalendarIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default CalendarIcon

--- a/src/components/icons/CircleAddIcon.jsx
+++ b/src/components/icons/CircleAddIcon.jsx
@@ -23,7 +23,7 @@ const CircleAddIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -75,7 +75,7 @@ CircleAddIcon.propTypes = {
 
 CircleAddIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default CircleAddIcon

--- a/src/components/icons/CloseIcon.jsx
+++ b/src/components/icons/CloseIcon.jsx
@@ -22,7 +22,7 @@ const CloseIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -73,7 +73,7 @@ CloseIcon.propTypes = {
 
 CloseIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default CloseIcon

--- a/src/components/icons/CopyPasteIcon.jsx
+++ b/src/components/icons/CopyPasteIcon.jsx
@@ -23,7 +23,7 @@ const CopyPasteIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -75,7 +75,7 @@ CopyPasteIcon.propTypes = {
 
 CopyPasteIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default CopyPasteIcon

--- a/src/components/icons/DatabaseIcon.jsx
+++ b/src/components/icons/DatabaseIcon.jsx
@@ -23,7 +23,7 @@ const DatabaseIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -75,7 +75,7 @@ DatabaseIcon.propTypes = {
 
 DatabaseIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default DatabaseIcon

--- a/src/components/icons/EditIcon.jsx
+++ b/src/components/icons/EditIcon.jsx
@@ -23,7 +23,7 @@ const EditIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -75,7 +75,7 @@ EditIcon.propTypes = {
 
 EditIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default EditIcon

--- a/src/components/icons/GearIcon.jsx
+++ b/src/components/icons/GearIcon.jsx
@@ -22,7 +22,7 @@ const GearIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -72,7 +72,7 @@ GearIcon.propTypes = {
 
 GearIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default GearIcon

--- a/src/components/icons/Users2Icon.jsx
+++ b/src/components/icons/Users2Icon.jsx
@@ -24,7 +24,7 @@ const Users2Icon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -78,7 +78,7 @@ Users2Icon.propTypes = {
 
 Users2Icon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default Users2Icon

--- a/src/components/icons/WorkspaceDynamicIcon.jsx
+++ b/src/components/icons/WorkspaceDynamicIcon.jsx
@@ -25,7 +25,7 @@ const WorkspaceDynamicIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -81,7 +81,7 @@ WorkspaceDynamicIcon.propTypes = {
 
 WorkspaceDynamicIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default WorkspaceDynamicIcon

--- a/src/components/icons/WorkspaceReadyIcon.jsx
+++ b/src/components/icons/WorkspaceReadyIcon.jsx
@@ -26,7 +26,7 @@ const WorkspaceReadyIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -138,7 +138,7 @@ WorkspaceReadyIcon.propTypes = {
 
 WorkspaceReadyIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default WorkspaceReadyIcon

--- a/src/components/icons/WorkspaceStaticIcon.jsx
+++ b/src/components/icons/WorkspaceStaticIcon.jsx
@@ -24,7 +24,7 @@ const WorkspaceStaticIcon = ({ color, size }) => {
         </svg>
       )
       break
-    case 'normal':
+    case 'medium':
       icon = (
         <svg
           width={24}
@@ -78,7 +78,7 @@ WorkspaceStaticIcon.propTypes = {
 
 WorkspaceStaticIcon.defaultProps = {
   color: 'main-dark-blue',
-  size: 'normal'
+  size: 'medium'
 }
 
 export default WorkspaceStaticIcon

--- a/src/stories/PlatformaticIcon.stories.jsx
+++ b/src/stories/PlatformaticIcon.stories.jsx
@@ -41,7 +41,7 @@ PlatformaticIconSmall.args = {
 export const PlatformaticIconNormal = AllIconsTemplate.bind({})
 PlatformaticIconNormal.args = {
   color: 'white',
-  size: 'normal'
+  size: 'medium'
 }
 
 export const PlatformaticIconLarge = AllIconsTemplate.bind({})


### PR DESCRIPTION
Hi @leorossi, @marcopiraccini 

basically I add a check on proptypes of icons size on `small`, `medium`, `large` and `extra-large`

Instead on the switch/case, case will checks on  `small`, `normal` `large` and `extra-large`.
And at last, default size was setted on `normal` 

So I replaced normal with medium... and also I updated the Readme with the instruction for npm