### PR TITLE
bugfix: adding min-h-screen instead of h-screen

### DIFF
--- a/src/components/TabbedWindow.module.css
+++ b/src/components/TabbedWindow.module.css
@@ -13,5 +13,5 @@
 }
 
 .tabs-content {
-  @apply h-screen
+  @apply min-h-screen
 }


### PR DESCRIPTION
Hi @marcopiraccini 

For fix this one
![image](https://user-images.githubusercontent.com/25035977/227284403-4972cb47-1b03-468f-bb19-ab008d271ff7.png)
