### PR TITLE
Feature/layout classname passed as props

### DIFF
--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -1,5 +1,5 @@
 .container {
-  @apply max-w-[216px] w-full p-4 border border-white rounded-md h-auto relative min-h-[80vh] z-10;
+  @apply max-w-[216px] w-full p-4 border border-white rounded-md h-auto relative min-h-[80vh] z-10 bg-dark-blue;
   transition: max-width 0.2s linear;
 }
 .collapsed {

--- a/src/components/icons/RestartIcon.jsx
+++ b/src/components/icons/RestartIcon.jsx
@@ -1,0 +1,79 @@
+import * as React from 'react'
+import PropTypes from 'prop-types'
+import styles from './Icons.module.css'
+import { COLORS_ICON, SIZES } from '../constants'
+
+const RestartIcon = ({ color, size }) => {
+  const className = `${styles.noShrinkForFlex} ` + styles[`${color}`]
+  let icon = <></>
+
+  switch (size) {
+    case 'small':
+      icon = (
+        <svg
+          width={16}
+          height={16}
+          viewBox='0 0 16 16'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          className={className}
+        >
+          <path d='M11.1765 9.05884V11.8824H14' stroke='none' strokeLinecap='round' strokeLinejoin='round' />
+          <path d='M7.64706 13.2941C4.52827 13.2941 2 10.7658 2 7.64706C2 4.52827 4.52827 2 7.64706 2C10.7658 2 13.2941 4.52827 13.2941 7.64706C13.2941 8.35328 13.1645 9.02922 12.9277 9.65238C12.6843 10.2929 12.3277 10.8777 11.8824 11.3823' stroke='none' strokeLinecap='round' strokeLinejoin='round' />
+        </svg>
+      )
+      break
+    case 'medium':
+      icon = (
+        <svg
+          width={24}
+          height={24}
+          viewBox='0 0 24 24'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          className={className}
+        >
+          <path d='M16.7646 13.5883V17.8236H20.9999' stroke='none' strokeWidth='1.5' strokeLinecap='round' strokeLinejoin='round' />
+          <path d='M11.4706 19.9412C6.79241 19.9412 3 16.1488 3 11.4706C3 6.79241 6.79241 3 11.4706 3C16.1488 3 19.9412 6.79241 19.9412 11.4706C19.9412 12.5299 19.7467 13.5438 19.3916 14.4786C19.0265 15.4394 18.4916 16.3166 17.8235 17.0735' stroke='none' strokeWidth={1.5} strokeLinecap='round' strokeLinejoin='round' />
+        </svg>
+      )
+      break
+    case 'large':
+      icon = (
+        <svg
+          width={40}
+          height={40}
+          viewBox='0 0 40 40'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          className={className}
+        >
+          <path d='M27.9412 22.647V29.7059H35' stroke='none' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' />
+          <path d='M19.1176 33.2353C11.3207 33.2353 5 26.9146 5 19.1176C5 11.3207 11.3207 5 19.1176 5C26.9146 5 33.2353 11.3207 33.2353 19.1176C33.2353 20.8832 32.9112 22.573 32.3193 24.1309C31.7108 25.7324 30.8193 27.1944 29.7059 28.4559' stroke='none' strokeWidth={2} strokeLinecap='round' strokeLinejoin='round' />
+        </svg>
+      )
+      break
+
+    default:
+      break
+  }
+  return icon
+}
+
+RestartIcon.propTypes = {
+  /**
+   * color of text, icon and borders
+   */
+  color: PropTypes.oneOf(COLORS_ICON),
+  /**
+   * Size
+   */
+  size: PropTypes.oneOf(SIZES)
+}
+
+RestartIcon.defaultProps = {
+  color: 'main-dark-blue',
+  size: 'medium'
+}
+
+export default RestartIcon

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -44,6 +44,7 @@ import LiveIcon from './LiveIcon'
 import LoadingAppIcon from './LoadingAppIcon'
 import LogOutIcon from './LogOutIcon'
 import MetricsIcon from './MetricsIcon'
+import RestartIcon from './RestartIcon'
 import PlayIcon from './PlayIcon'
 import PullRequestIcon from './PullRequestIcon'
 import SendIcon from './SendIcon'
@@ -112,6 +113,7 @@ export default {
   MetricsIcon,
   PlayIcon,
   PullRequestIcon,
+  RestartIcon,
   SendIcon,
   StopIcon,
   SocialDiscordIcon,

--- a/src/components/layouts/Layout.jsx
+++ b/src/components/layouts/Layout.jsx
@@ -1,11 +1,30 @@
 'use strict'
 import React from 'react'
+import PropTypes from 'prop-types'
 
-export default function Layout (props) {
+function Layout ({ className, children }) {
   return (
-    <div className='container mx-auto px-5 my-5 flex flex-col gap-10 h-screen'>
-      {props.children}
+    <div className={className}>
+      {children}
     </div>
 
   )
 }
+
+Layout.propTypes = {
+  /**
+   * className
+   */
+  className: PropTypes.string,
+  /**
+   * children
+   */
+  children: PropTypes.node
+}
+
+Layout.defaultProps = {
+  className: 'container mx-auto px-5 my-5 flex flex-col gap-10 h-screen',
+  children: null
+}
+
+export default Layout


### PR DESCRIPTION
Hi @marcopiraccini 

the problem for this one https://github.com/platformatic/dashformatic/issues/241 is splitted in two part.

the first one is the h-screen on the className (in the pr, we can pass it as props, handling the layout on dashformatic, and however the className has a default value). 
the second one instead is on dashformatic, class on Dashboard.module.css

I also added a new Icon
