### PR TITLE
chore: removing fortawesome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,6 @@
       "version": "0.1.75",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.2.0",
-        "@fortawesome/free-brands-svg-icons": "^6.2.0",
-        "@fortawesome/free-regular-svg-icons": "^6.2.0",
-        "@fortawesome/free-solid-svg-icons": "^6.2.0",
-        "@fortawesome/react-fontawesome": "^0.2.0",
         "autoprefixer": "^10.4.12",
         "postcss": "^8.4.17",
         "react": "^18.2.0",
@@ -2060,70 +2055,6 @@
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.2.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.2.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.2.0",
-      "hasInstallScript": true,
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.0.tgz",
-      "integrity": "sha512-M1dG+PAmkYMTL9BSUHFXY5oaHwBYfHCPhbJ8qj8JELsc9XCrUJ6eEHWip4q0tE+h9C0DVyFkwIM9t7QYyCpprQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.2.0",
-      "hasInstallScript": true,
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
       }
     },
     "node_modules/@gar/promisify": {
@@ -22518,41 +22449,6 @@
       "requires": {
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
-      }
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "6.2.0"
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "6.2.0",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      }
-    },
-    "@fortawesome/free-brands-svg-icons": {
-      "version": "6.2.0",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      }
-    },
-    "@fortawesome/free-regular-svg-icons": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.0.tgz",
-      "integrity": "sha512-M1dG+PAmkYMTL9BSUHFXY5oaHwBYfHCPhbJ8qj8JELsc9XCrUJ6eEHWip4q0tE+h9C0DVyFkwIM9t7QYyCpprQ==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "6.2.0",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.0"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "requires": {
-        "prop-types": "^15.8.1"
       }
     },
     "@gar/promisify": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,6 @@
     "prepare": "rm -Rf dist; npm run build; npm run tailwind"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.2.0",
-    "@fortawesome/free-brands-svg-icons": "^6.2.0",
-    "@fortawesome/free-regular-svg-icons": "^6.2.0",
-    "@fortawesome/free-solid-svg-icons": "^6.2.0",
-    "@fortawesome/react-fontawesome": "^0.2.0",
     "autoprefixer": "^10.4.12",
     "postcss": "^8.4.17",
     "react": "^18.2.0",


### PR DESCRIPTION
Hi @marcopiraccini @leorossi 

I removed from package.json and package.lock.json font|fort awesome (using nom uninstall).

testing locally storybook still works, and also dashformatic.