### PR TITLE
feat: inverting colors of drop down menu

### DIFF
--- a/src/components/Common.module.css
+++ b/src/components/Common.module.css
@@ -46,6 +46,9 @@
 .text--main-dark-blue {
   @apply text-main-dark-blue;
 }
+.text--light-blue {
+  @apply text-light-blue;
+}
 
 .text--base {
   @apply text-base

--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -1,35 +1,88 @@
 'use strict'
-
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import styles from './DropDown.module.css'
+import commonStyles from './Common.module.css'
 import PlatformaticIcon from './PlatformaticIcon'
-export default function DropDown (props) {
-  const { pictureUrl, header, items, align = 'left' } = props
+import { LIGHT_BLUE, MAIN_DARK_BLUE, WHITE } from './constants'
+function DropDown ({ pictureUrl, header, items, align, backgroundColor, textColor, borderColor }) {
   const [open, setOpen] = useState(false)
+
+  let classNameMenu = `${styles.menu} `
+  classNameMenu += commonStyles[`background-color-${backgroundColor}`]
+  classNameMenu += ' ' + commonStyles[`bordered--${borderColor}`]
+
+  let classNameItem = `${styles.item} `
+  classNameItem += commonStyles[`text--${textColor}`]
+
+  let headerClassNamme = `${styles.header} `
+  headerClassNamme += commonStyles[`text--${borderColor}`]
+
   function handleOpen () {
     setOpen(!open)
   }
+
   return (
     <div className={`${styles.dropDown} ${styles[align]}`}>
-      <span className={styles.header} onClick={handleOpen}>
+      <span className={headerClassNamme} onClick={handleOpen}>
         {pictureUrl && <img src={pictureUrl} height={32} width={32} className={styles.picture} />}
         {header}
-        {!open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowRightIcon' color='white' onClick={null} /></div>}
-        {open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowDownIcon' color='white' onClick={null} /></div>}
+        {!open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowRightIcon' color={borderColor} onClick={null} /></div>}
+        {open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowDownIcon' color={borderColor} onClick={null} /></div>}
       </span>
       {open && (
-        <div className={styles.menu}>
+        <div className={classNameMenu}>
           {items.map((item, index) => {
             return (
-              <div className={styles.item} key={index}>
+              <div className={classNameItem} key={index}>
                 {item}
               </div>
             )
           })}
         </div>
       )}
-
     </div>
-
   )
 }
+
+DropDown.propTypes = {
+  /**
+   * pictureUrl
+   */
+  pictureUrl: PropTypes.string,
+  /**
+   * header
+   */
+  header: PropTypes.string,
+  /**
+   * align
+   */
+  align: PropTypes.string,
+  /**
+   * items
+   */
+  items: PropTypes.array,
+  /**
+   * backgroundColor
+   */
+  backgroundColor: PropTypes.oneOf([MAIN_DARK_BLUE, LIGHT_BLUE]),
+  /**
+   * textColor
+   */
+  textColor: PropTypes.oneOf([MAIN_DARK_BLUE, LIGHT_BLUE]),
+  /**
+   * borderColor
+   */
+  borderColor: PropTypes.oneOf([MAIN_DARK_BLUE, WHITE])
+}
+
+DropDown.defaultProps = {
+  pictureUrl: '',
+  header: '',
+  align: 'left',
+  items: [],
+  backgroundColor: LIGHT_BLUE,
+  textColor: MAIN_DARK_BLUE,
+  borderColor: WHITE
+}
+export default DropDown

--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -5,7 +5,7 @@ import styles from './DropDown.module.css'
 import commonStyles from './Common.module.css'
 import PlatformaticIcon from './PlatformaticIcon'
 import { LIGHT_BLUE, MAIN_DARK_BLUE, WHITE } from './constants'
-function DropDown ({ pictureUrl, header, items, align, backgroundColor, textColor, borderColor }) {
+function DropDown ({ pictureUrl, header, items, align, backgroundColor, textColor, borderColor, headerColor }) {
   const [open, setOpen] = useState(false)
 
   let classNameMenu = `${styles.menu} `
@@ -16,7 +16,7 @@ function DropDown ({ pictureUrl, header, items, align, backgroundColor, textColo
   classNameItem += commonStyles[`text--${textColor}`]
 
   let headerClassNamme = `${styles.header} `
-  headerClassNamme += commonStyles[`text--${borderColor}`]
+  headerClassNamme += commonStyles[`text--${headerColor}`]
 
   function handleOpen () {
     setOpen(!open)
@@ -27,8 +27,8 @@ function DropDown ({ pictureUrl, header, items, align, backgroundColor, textColo
       <span className={headerClassNamme} onClick={handleOpen}>
         {pictureUrl && <img src={pictureUrl} height={32} width={32} className={styles.picture} />}
         {header}
-        {!open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowRightIcon' color={borderColor} onClick={null} /></div>}
-        {open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowDownIcon' color={borderColor} onClick={null} /></div>}
+        {!open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowRightIcon' color={headerColor} onClick={null} /></div>}
+        {open && <div className={styles.arrow}><PlatformaticIcon iconName='ArrowDownIcon' color={headerColor} onClick={null} /></div>}
       </span>
       {open && (
         <div className={classNameMenu}>
@@ -73,7 +73,11 @@ DropDown.propTypes = {
   /**
    * borderColor
    */
-  borderColor: PropTypes.oneOf([MAIN_DARK_BLUE, WHITE])
+  borderColor: PropTypes.oneOf([MAIN_DARK_BLUE, WHITE]),
+  /**
+   * headerColor
+   */
+  headerColor: PropTypes.oneOf([MAIN_DARK_BLUE, WHITE])
 }
 
 DropDown.defaultProps = {
@@ -83,6 +87,7 @@ DropDown.defaultProps = {
   items: [],
   backgroundColor: LIGHT_BLUE,
   textColor: MAIN_DARK_BLUE,
+  headerColor: WHITE,
   borderColor: WHITE
 }
 export default DropDown

--- a/src/components/DropDown.module.css
+++ b/src/components/DropDown.module.css
@@ -17,10 +17,8 @@
   @apply border border-transparent rounded-full mr-2;
 }
 .menu {
-  @apply absolute border-solid border border-white p-0 bg-light-blue mt-8 rounded-md z-10 text-sm min-w-[190px];
+  @apply absolute border-solid border p-0  mt-8 rounded-md z-10 text-sm min-w-[190px];
 }
 .item {
-  @apply py-2 px-3 text-main-dark-blue first:border-t-0 text-sm leading-4 uppercase hover:font-semibold hover:cursor-pointer tracking-more-widest; 
-  /* it's a workaround due to opacity... */
-  border-top: 1px solid rgba(0, 40, 61, 0.2);;
+  @apply py-2 px-3 first:border-t-0 text-sm leading-4 uppercase hover:font-semibold hover:cursor-pointer tracking-more-widest border-t; 
 }

--- a/src/components/DropDown.module.css
+++ b/src/components/DropDown.module.css
@@ -20,5 +20,5 @@
   @apply absolute border-solid border p-0  mt-8 rounded-md z-10 text-sm min-w-[190px];
 }
 .item {
-  @apply py-2 px-3 first:border-t-0 text-sm leading-4 uppercase hover:font-semibold hover:cursor-pointer tracking-more-widest border-t; 
+  @apply py-2 px-3 first:border-t-0 text-sm leading-4 uppercase hover:font-semibold hover:cursor-pointer tracking-more-widest border-t;
 }


### PR DESCRIPTION
Hi @marcopiraccini 

I added some logic to have a dropdown menu that could be used on light and dartk menu (useful for settings menù)

-  normal
<img width="349" alt="Schermata 2023-04-25 alle 23 17 51" src="https://user-images.githubusercontent.com/25035977/234406147-3d511ba6-5e48-40ce-a29d-a6f41ec791dc.png">

- inverted
<img width="363" alt="Schermata 2023-04-25 alle 23 21 06" src="https://user-images.githubusercontent.com/25035977/234406748-7716ddbe-7633-43ed-9873-933b198d25bc.png">
